### PR TITLE
Allow RSpec to update to latest

### DIFF
--- a/runbook.gemspec
+++ b/runbook.gemspec
@@ -49,5 +49,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.13"
   spec.add_development_dependency "pry-byebug", "~> 3.6"
   spec.add_development_dependency "rake", "~> 12.3"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rspec", "~> 3"
 end


### PR DESCRIPTION
https://github.com/doolin/runbook/issues/3

RSpec is pretty stable, pin only the major
version.